### PR TITLE
expose rocksdb options to config

### DIFF
--- a/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
+++ b/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
@@ -46,6 +46,8 @@ search.text_analyzer_mode=INDEX
 # rocksdb backend config
 #rocksdb.data_path=/path/to/disk
 #rocksdb.wal_path=/path/to/disk
+rocksdb.enable_pipeline_write=true
+rocksdb.recycle_log_file_num=1
 
 
 # cassandra backend config

--- a/hugegraph-dist/src/assembly/static/conf/rest-server.properties
+++ b/hugegraph-dist/src/assembly/static/conf/rest-server.properties
@@ -19,6 +19,8 @@ server.start_ignore_single_graph_error=true
 # The maximum thread ratio for batch writing, only take effect if the batch.max_write_threads is 0
 batch.max_write_ratio=80
 batch.max_write_threads=0
+batch.max_vertices_per_batch=2000
+batch.max_edges_per_batch=2000
 
 # authentication configs
 # choose 'com.baidu.hugegraph.auth.StandardAuthenticator' or 'com.baidu.hugegraph.auth.ConfigAuthenticator'

--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBOptions.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBOptions.java
@@ -243,6 +243,46 @@ public class RocksDBOptions extends OptionHolder {
                     0L
             );
 
+    public static final ConfigOption<Boolean> UNORDERED_WRITE =
+            new ConfigOption<>(
+                    "rocksdb.unordered_write",
+                    "enable unordered write",
+                    disallowEmpty(),
+                    false
+            );
+
+    public static final ConfigOption<Boolean> ENABLE_PIPELINE_WRITE =
+            new ConfigOption<>(
+                    "rocksdb.enable_pipeline_write",
+                    "enable pipeline write",
+                    disallowEmpty(),
+                    false
+            );
+
+    public static final ConfigOption<Boolean> DISABLE_WAL =
+            new ConfigOption<>(
+                    "rocksdb.disable_wal",
+                    "disable wal for rocksdb",
+                    disallowEmpty(),
+                    false
+            );
+
+    public static final ConfigOption<Integer> RECYCLE_LOG_FILE_NUM =
+            new ConfigOption<>(
+                    "rocksdb.recycle_log_file_num",
+                    "set reuse log file num for saving io-ops",
+                    rangeInt(0, Integer.MAX_VALUE),
+                    0
+            );
+
+    public static final ConfigOption<Boolean> WAIT_FOR_FLUSH =
+            new ConfigOption<>(
+                    "rocksdb.wait_for_flush",
+                    "wait for flush",
+                    disallowEmpty(),
+                    false
+            );
+
     public static final ConfigOption<Long> DELETE_OBSOLETE_FILE_PERIOD =
             new ConfigOption<>(
                     "rocksdb.delete_obsolete_files_period",


### PR DESCRIPTION
1. make rocksdb options (enable_pipeline_write, unordered_write, disable_wal, recycle_log_file_num and wait_for_flush) configurable
2. set default value for enable_pipeline_write and recycle_log_file_num in hugegraph.properties.
3. set default value for max_vertices_per_batch and max_edges_per_batch in rest-server.properties