### PR TITLE
Skip edge deserialization

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/query/Query.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/query/Query.java
@@ -65,6 +65,7 @@ public class Query implements Cloneable {
     private boolean showDeleting;
     private boolean showExpired;
     private boolean olap;
+    private boolean withProperties;
     private Set<Id> olapPks;
 
     private Aggregate aggregate;
@@ -92,6 +93,8 @@ public class Query implements Cloneable {
         this.showHidden = false;
         this.showDeleting = false;
 
+        this.withProperties = true;
+
         this.aggregate = null;
         this.showExpired = false;
         this.olap = false;
@@ -106,6 +109,8 @@ public class Query implements Cloneable {
         this.capacity = query.capacity();
         this.showHidden = query.showHidden();
         this.showDeleting = query.showDeleting();
+        this.withProperties = query.withProperties();
+
         this.aggregate = query.aggregate();
         this.showExpired = query.showExpired();
         this.olap = query.olap();
@@ -427,6 +432,14 @@ public class Query implements Cloneable {
 
     public boolean showDeleting() {
         return this.showDeleting;
+    }
+
+    public void withProperties(boolean withProperties) {
+        this.withProperties = withProperties;
+    }
+
+    public boolean withProperties() {
+        return this.withProperties;
     }
 
     public void showDeleting(boolean showDeleting) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/AbstractSerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/AbstractSerializer.java
@@ -19,12 +19,14 @@
 
 package com.baidu.hugegraph.backend.serializer;
 
+import com.baidu.hugegraph.HugeGraph;
 import com.baidu.hugegraph.backend.BackendException;
 import com.baidu.hugegraph.backend.id.Id;
 import com.baidu.hugegraph.backend.query.ConditionQuery;
 import com.baidu.hugegraph.backend.query.IdQuery;
 import com.baidu.hugegraph.backend.query.Query;
 import com.baidu.hugegraph.backend.store.BackendEntry;
+import com.baidu.hugegraph.structure.HugeVertex;
 import com.baidu.hugegraph.type.HugeType;
 
 public abstract class AbstractSerializer
@@ -75,5 +77,10 @@ public abstract class AbstractSerializer
         }
 
         return query;
+    }
+
+    @Override
+    public HugeVertex readVertex(HugeGraph graph, BackendEntry entry) {
+        return readVertex(graph, entry, true);
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinaryScatterSerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinaryScatterSerializer.java
@@ -56,7 +56,8 @@ public class BinaryScatterSerializer extends BinarySerializer {
     }
 
     @Override
-    public HugeVertex readVertex(HugeGraph graph, BackendEntry bytesEntry) {
+    public HugeVertex readVertex(HugeGraph graph, BackendEntry bytesEntry,
+                                 boolean withEdgeProperties) {
         if (bytesEntry == null) {
             return null;
         }
@@ -77,7 +78,7 @@ public class BinaryScatterSerializer extends BinarySerializer {
 
         // Parse all properties and edges of a Vertex
         for (BackendColumn col : entry.columns()) {
-            this.parseColumn(col, vertex);
+            this.parseColumn(col, vertex, withEdgeProperties);
         }
 
         return vertex;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinarySerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinarySerializer.java
@@ -249,7 +249,7 @@ public class BinarySerializer extends AbstractSerializer {
     }
 
     protected void parseEdge(BackendColumn col, HugeVertex vertex,
-                             HugeGraph graph) {
+                             HugeGraph graph, boolean withEdgeProperties) {
         // owner-vertex + dir + edge-label + sort-values + other-vertex
 
         BytesBuffer buffer = BytesBuffer.wrap(col.name);
@@ -269,6 +269,9 @@ public class BinarySerializer extends AbstractSerializer {
         HugeEdge edge = HugeEdge.constructEdge(vertex, direction, edgeLabel,
                                                sortValues, otherVertexId);
 
+        if(!withEdgeProperties) {
+            return;
+        }
         // Parse edge-id + edge-properties
         buffer = BytesBuffer.wrap(col.value);
 
@@ -300,7 +303,8 @@ public class BinarySerializer extends AbstractSerializer {
         }
     }
 
-    protected void parseColumn(BackendColumn col, HugeVertex vertex) {
+    protected void parseColumn(BackendColumn col, HugeVertex vertex,
+                               boolean withEdgeProperties) {
         BytesBuffer buffer = BytesBuffer.wrap(col.name);
         Id id = this.keyWithIdPrefix ? buffer.readId() : vertex.id();
         E.checkState(buffer.remaining() > 0, "Missing column type");
@@ -313,7 +317,7 @@ public class BinarySerializer extends AbstractSerializer {
         // Parse edge
         else if (type == HugeType.EDGE_IN.code() ||
                  type == HugeType.EDGE_OUT.code()) {
-            this.parseEdge(col, vertex, vertex.graph());
+            this.parseEdge(col, vertex, vertex.graph(), withEdgeProperties);
         }
         // Parse system property
         else if (type == HugeType.SYS_PROPERTY.code()) {
@@ -430,7 +434,8 @@ public class BinarySerializer extends AbstractSerializer {
     }
 
     @Override
-    public HugeVertex readVertex(HugeGraph graph, BackendEntry bytesEntry) {
+    public HugeVertex readVertex(HugeGraph graph, BackendEntry bytesEntry,
+                                 boolean withEdgeProperties) {
         if (bytesEntry == null) {
             return null;
         }
@@ -448,7 +453,7 @@ public class BinarySerializer extends AbstractSerializer {
             if (entry.type().isEdge()) {
                 // NOTE: the entry id type is vertex even if entry type is edge
                 // Parse vertex edges
-                this.parseColumn(col, vertex);
+                this.parseColumn(col, vertex, withEdgeProperties);
             } else {
                 assert entry.type().isVertex();
                 // Parse vertex properties

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinarySerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinarySerializer.java
@@ -269,7 +269,9 @@ public class BinarySerializer extends AbstractSerializer {
         HugeEdge edge = HugeEdge.constructEdge(vertex, direction, edgeLabel,
                                                sortValues, otherVertexId);
 
-        if(!withEdgeProperties) {
+        if (!withEdgeProperties && !edge.hasTtl()) {
+            // only skip properties for edge without ttl
+            // todo: save expiredTime before properties
             return;
         }
         // Parse edge-id + edge-properties

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/GraphSerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/GraphSerializer.java
@@ -37,6 +37,8 @@ public interface GraphSerializer {
     public BackendEntry writeOlapVertex(HugeVertex vertex);
     public BackendEntry writeVertexProperty(HugeVertexProperty<?> prop);
     public HugeVertex readVertex(HugeGraph graph, BackendEntry entry);
+    public HugeVertex readVertex(HugeGraph graph, BackendEntry entry,
+                                 boolean withEdgeProperties);
 
     public BackendEntry writeEdge(HugeEdge edge);
     public BackendEntry writeEdgeProperty(HugeEdgeProperty<?> prop);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/TableSerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/TableSerializer.java
@@ -225,7 +225,8 @@ public abstract class TableSerializer extends AbstractSerializer {
     }
 
     @Override
-    public HugeVertex readVertex(HugeGraph graph, BackendEntry backendEntry) {
+    public HugeVertex readVertex(HugeGraph graph, BackendEntry backendEntry,
+                                 boolean withEdgeProperties) {
         E.checkNotNull(graph, "serializer graph");
         if (backendEntry == null) {
             return null;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/TextSerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/TextSerializer.java
@@ -294,7 +294,8 @@ public class TextSerializer extends AbstractSerializer {
     }
 
     @Override
-    public HugeVertex readVertex(HugeGraph graph, BackendEntry backendEntry) {
+    public HugeVertex readVertex(HugeGraph graph, BackendEntry backendEntry,
+                                 boolean withEdgeProperties) {
         E.checkNotNull(graph, "serializer graph");
         if (backendEntry == null) {
             return null;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
@@ -983,7 +983,7 @@ public class GraphTransaction extends IndexableTransaction {
 
         Iterator<HugeEdge> edges = new FlatMapperIterator<>(entries, entry -> {
             // Edges are in a vertex
-            HugeVertex vertex = this.parseEntry(entry);
+            HugeVertex vertex = this.parseEntry(entry, query.withProperties());
             if (vertex == null) {
                 return null;
             }
@@ -1877,8 +1877,12 @@ public class GraphTransaction extends IndexableTransaction {
     }
 
     private HugeVertex parseEntry(BackendEntry entry) {
+        return this.parseEntry(entry, true);
+    }
+
+    private HugeVertex parseEntry(BackendEntry entry, boolean withProperty) {
         try {
-            HugeVertex vertex = this.serializer.readVertex(graph(), entry);
+            HugeVertex vertex = this.serializer.readVertex(graph(), entry, withProperty);
             assert vertex != null;
             return vertex;
         } catch (ForbiddenException | SecurityException e) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/CountTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/CountTraverser.java
@@ -99,7 +99,7 @@ public class CountTraverser extends HugeTraverser {
         if (this.dedup(source)) {
             return QueryResults.emptyIterator();
         }
-        Iterator<Edge> flatten = this.edgesOfVertex(source, step);
+        Iterator<Edge> flatten = this.edgesOfVertex(source, step, false);
         return new FilterIterator<>(flatten, e -> {
             if (this.containsTraversed) {
                 // Count intermediate vertices

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/CustomizePathsTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/CustomizePathsTraverser.java
@@ -70,11 +70,12 @@ public class CustomizePathsTraverser extends HugeTraverser {
             stepNum--;
             newVertices = newMultivalueMap();
             Iterator<Edge> edges;
+            boolean withProperties = sorted && step.weightBy() != null;
 
             // Traversal vertices of previous level
             for (Map.Entry<Id, List<Node>> entry : sources.entrySet()) {
                 List<Node> adjacency = newList();
-                edges = this.edgesOfVertex(entry.getKey(), step.step());
+                edges = this.edgesOfVertex(entry.getKey(), step.step(), withProperties);
                 while (edges.hasNext()) {
                     HugeEdge edge = (HugeEdge) edges.next();
                     Id target = edge.id().otherVertexId();

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/CustomizedCrosspointsTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/CustomizedCrosspointsTraverser.java
@@ -80,7 +80,7 @@ public class CustomizedCrosspointsTraverser extends HugeTraverser {
                 // Traversal vertices of previous level
                 for (Map.Entry<Id, List<Node>> entry : sources.entrySet()) {
                     List<Node> adjacency = newList();
-                    edges = this.edgesOfVertex(entry.getKey(), step.edgeStep);
+                    edges = this.edgesOfVertex(entry.getKey(), step.edgeStep, false);
                     while (edges.hasNext()) {
                         HugeEdge edge = (HugeEdge) edges.next();
                         Id target = edge.id().otherVertexId();

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/FusiformSimilarityTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/FusiformSimilarityTraverser.java
@@ -103,7 +103,7 @@ public class FusiformSimilarityTraverser extends HugeTraverser {
         Id labelId = this.getEdgeLabelId(label);
         // Get similar nodes and counts
         Iterator<Edge> edges = this.edgesOfVertex(vertex.id(), direction,
-                                                  labelId, degree);
+                                                  labelId, degree, false);
         Map<Id, MutableInt> similars = newMap();
         MultivaluedMap<Id, Id> intermediaries = new MultivaluedHashMap<>();
         Set<Id> neighbors = newIdSet();
@@ -117,7 +117,7 @@ public class FusiformSimilarityTraverser extends HugeTraverser {
 
             Directions backDir = direction.opposite();
             Iterator<Edge> backEdges = this.edgesOfVertex(target, backDir,
-                                                          labelId, degree);
+                                                          labelId, degree, false);
             Set<Id> currentSimilars = newIdSet();
             while (backEdges.hasNext()) {
                 Id node = ((HugeEdge) backEdges.next()).id().otherVertexId();
@@ -220,10 +220,10 @@ public class FusiformSimilarityTraverser extends HugeTraverser {
         }
         if (edgeLabel != null && edgeLabel.frequency() == Frequency.SINGLE) {
             edges = this.edgesOfVertex(vertex.id(), direction,
-                                       labelId, minNeighbors);
+                                       labelId, minNeighbors, false);
             neighborCount = IteratorUtils.count(edges);
         } else {
-            edges = this.edgesOfVertex(vertex.id(), direction, labelId, degree);
+            edges = this.edgesOfVertex(vertex.id(), direction, labelId, degree, false);
             Set<Id> neighbors = newIdSet();
             while (edges.hasNext()) {
                 Id target = ((HugeEdge) edges.next()).id().otherVertexId();

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -447,10 +447,6 @@ public class HugeTraverser {
         return steps.skipSuperNodeIfNeeded(edges);
     }
 
-//    protected Iterator<Edge> edgesOfVertex(Id source, EdgeStep edgeStep) {
-//        return edgesOfVertex(source, edgeStep, true);
-//    }
-
     protected Iterator<Edge> edgesOfVertex(Id source, EdgeStep edgeStep,
                                          boolean withProperties) {
         if (edgeStep.properties() == null || edgeStep.properties().isEmpty()) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -134,7 +134,7 @@ public class HugeTraverser {
         Set<Id> neighbors = newIdSet();
         for (Id source : vertices) {
             Iterator<Edge> edges = this.edgesOfVertex(source, dir,
-                                                      label, degree);
+                                                      label, degree, false);
             while (edges.hasNext()) {
                 this.edgeIterCounter++;
                 HugeEdge e = (HugeEdge) edges.next();
@@ -156,7 +156,7 @@ public class HugeTraverser {
 
     protected Iterator<Id> adjacentVertices(Id source, Directions dir,
                                             Id label, long limit) {
-        Iterator<Edge> edges = this.edgesOfVertex(source, dir, label, limit);
+        Iterator<Edge> edges = this.edgesOfVertex(source, dir, label, limit, false);
         return new MapperIterator<>(edges, e -> {
             HugeEdge edge = (HugeEdge) e;
             return edge.id().otherVertexId();
@@ -179,7 +179,8 @@ public class HugeTraverser {
 
     @Watched
     protected Iterator<Edge> edgesOfVertex(Id source, Directions dir,
-                                           Id label, long limit) {
+                                           Id label, long limit,
+                                           boolean withEdgeProperties) {
         Id[] labels = {};
         if (label != null) {
             labels = new Id[]{label};
@@ -189,13 +190,15 @@ public class HugeTraverser {
         if (limit != NO_LIMIT) {
             query.limit(limit);
         }
+        query.withProperties(withEdgeProperties);
         return this.graph.edges(query);
     }
 
     @Watched
     protected Iterator<Edge> edgesOfVertexAF(Id source, Directions dir,
                                              Id label, long limit,
-                                             Steps steps) {
+                                             Steps steps,
+                                             boolean withEdgeProperties) {
         Id[] labels = {};
         if (label != null) {
             labels = new Id[]{label};
@@ -205,6 +208,9 @@ public class HugeTraverser {
         if (limit != NO_LIMIT) {
             query.limit(limit);
         }
+        // check if we need edgeProperties.
+        query.withProperties(withEdgeProperties ||
+                                     !steps.isEdgeStepPropertiesEmpty());
 
         Iterator<Edge> result = this.graph.edges(query);
         return edgesOfVertexStep(result, steps);
@@ -369,14 +375,15 @@ public class HugeTraverser {
 
     @Watched
     protected Iterator<Edge> edgesOfVertex(Id source, Directions dir,
-                                           Map<Id, String> labels, long limit) {
+                                           Map<Id, String> labels, long limit,
+                                           boolean withProperties) {
         if (labels == null || labels.isEmpty()) {
-            return this.edgesOfVertex(source, dir, (Id) null, limit);
+            return this.edgesOfVertex(source, dir, (Id) null, limit, withProperties);
         }
         ExtendableIterator<Edge> results = new ExtendableIterator<>();
         for (Id label : labels.keySet()) {
             E.checkNotNull(label, "edge label");
-            results.extend(this.edgesOfVertex(source, dir, label, limit));
+            results.extend(this.edgesOfVertex(source, dir, label, limit, withProperties));
         }
 
         if (limit == NO_LIMIT) {
@@ -392,15 +399,17 @@ public class HugeTraverser {
     @Watched
     protected Iterator<Edge> edgesOfVertexAF(Id source, Directions dir,
                                              Id[] labels, long limit,
-                                             Steps steps) {
+                                             Steps steps,
+                                             boolean withEdgeProperties) {
         if (labels == null || labels.length == 0) {
-            return this.edgesOfVertexAF(source, dir, (Id) null, limit, steps);
+            return this.edgesOfVertexAF(source, dir, (Id) null,
+                                        limit, steps, withEdgeProperties);
         }
         ExtendableIterator<Edge> results = new ExtendableIterator<>();
         for (Id label : labels) {
             E.checkNotNull(label, "edge label");
             results.extend(this.edgesOfVertexAF(source, dir, label,
-                                                limit, steps));
+                                                limit, steps, withEdgeProperties));
         }
 
         if (limit == NO_LIMIT) {
@@ -418,20 +427,23 @@ public class HugeTraverser {
             Iterator<Edge> edges = this.edgesOfVertex(source,
                                                       edgeStep.direction(),
                                                       edgeStep.labels(),
-                                                      edgeStep.limit());
+                                                      edgeStep.limit(),
+                                                      false);
             return edgeStep.skipSuperNodeIfNeeded(edges);
         }
         return this.edgesOfVertex(source, edgeStep, false);
     }
 
-    protected Iterator<Edge> edgesOfVertexAF(Id source, Steps steps) {
+    protected Iterator<Edge> edgesOfVertexAF(Id source, Steps steps,
+                                             boolean withEdgeProperties) {
 
         if (steps.isEdgeStepPropertiesEmpty()) {
             Iterator<Edge> edges = this.edgesOfVertexAF(source,
                                                         steps.direction(),
                                                         steps.edgeLabels(),
                                                         steps.limit(),
-                                                        steps);
+                                                        steps,
+                                                        withEdgeProperties);
             return steps.skipSuperNodeIfNeeded(edges);
         }
 
@@ -442,6 +454,7 @@ public class HugeTraverser {
         if (steps.limit() != NO_LIMIT) {
             query.limit(steps.limit());
         }
+//        query.withProperties(withEdgeProperties);
         Iterator<Edge> edges = this.graph().edges(query);
         edges = edgesOfVertexStep(edges, steps);
         return steps.skipSuperNodeIfNeeded(edges);
@@ -987,6 +1000,7 @@ public class HugeTraverser {
         // cache for edges, initial capacity to avoid mem-fragment
         private final ArrayList<HugeEdge> cache = new ArrayList<>(MAX_CACHED_COUNT);
         private int cachePointer = 0;
+        private boolean withEdgeProperties;
 
         // of parent
         private HugeEdge currentEdge = null;
@@ -995,11 +1009,13 @@ public class HugeTraverser {
         // todo: may add edge-filter and/or vertice-filter ...
 
         public NestedIterator(HugeTraverser traverser, Iterator<Edge> parent,
-                              Steps steps, Set<Id> visited) {
+                              Steps steps, Set<Id> visited,
+                              boolean withEdgeProperties) {
             this.traverser = traverser;
             this.parentIterator = parent;
             this.steps = steps;
             this.visited = visited;
+            this.withEdgeProperties = withEdgeProperties;
         }
 
         @Override
@@ -1025,7 +1041,7 @@ public class HugeTraverser {
                 this.cachePointer++;
                 this.currentIterator = traverser.edgesOfVertexAF(
                         this.currentEdge.id().otherVertexId(),
-                        steps);
+                        steps, withEdgeProperties);
             }
             return true;
         }
@@ -1061,16 +1077,17 @@ public class HugeTraverser {
     }
 
     public Iterator<Edge> createNestedIterator(Id sourceV, Steps steps, int depth,
-                                               Set<Id> visited) {
+                                               Set<Id> visited,
+                                               boolean withEdgeProperties) {
         E.checkArgument(depth > 0,
                         "The depth should large than 0 for nested iterator");
 
         visited.add(sourceV);
 
         // build a chained iterator path with length of depth
-        Iterator<Edge> it = this.edgesOfVertexAF(sourceV, steps);
+        Iterator<Edge> it = this.edgesOfVertexAF(sourceV, steps, withEdgeProperties);
         for (int i = 1; i < depth; i++) {
-            it = new NestedIterator(this, it, steps, visited);
+            it = new NestedIterator(this, it, steps, visited, withEdgeProperties);
         }
         return it;
     }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/KneighborTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/KneighborTraverser.java
@@ -87,10 +87,11 @@ public class KneighborTraverser extends OltpTraverser {
             if (this.reachLimit(limit, records.size())) {
                 return;
             }
-            Iterator<Edge> edges = edgesOfVertexAF(v, steps);
+            Iterator<Edge> edges = edgesOfVertexAF(v, steps, false);
             while (!this.reachLimit(limit, records.size())
                    && edges.hasNext()) {
                 HugeEdge edge = (HugeEdge) edges.next();
+                this.edgeIterCounter ++;
                 Id target = edge.id().otherVertexId();
                 records.addPath(v, target);
                 if(withEdge) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/KoutTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/KoutTraverser.java
@@ -121,7 +121,7 @@ public class KoutTraverser extends OltpTraverser {
                 return;
             }
 
-            Iterator<Edge> edges = edgesOfVertexAF(v, steps);
+            Iterator<Edge> edges = edgesOfVertexAF(v, steps, false);
             while (!this.reachLimit(limit, depth[0], records.size()) &&
                    edges.hasNext()) {
                 HugeEdge edge = (HugeEdge) edges.next();
@@ -167,7 +167,7 @@ public class KoutTraverser extends OltpTraverser {
                                               sourceV, nearest, depth);
 
         Iterator<Edge> it = this.createNestedIterator(sourceV, steps,
-                                                      depth, all);
+                                                      depth, all, false);
         while (it.hasNext()) {
             this.edgeIterCounter++;
             HugeEdge edge = (HugeEdge) it.next();
@@ -205,7 +205,7 @@ public class KoutTraverser extends OltpTraverser {
                 return;
             }
 
-            Iterator<Edge> edges = edgesOfVertexAF(v, steps);
+            Iterator<Edge> edges = edgesOfVertexAF(v, steps, false);
             while (!this.reachLimit(limit, depth[0], cur.size()) &&
                     edges.hasNext()) {
                 HugeEdge edge = (HugeEdge) edges.next();

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/NeighborRankTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/NeighborRankTraverser.java
@@ -73,7 +73,7 @@ public class NeighborRankTraverser extends HugeTraverser {
             for (Map.Entry<Id, List<Node>> entry : sources.entrySet()) {
                 Id vertex = entry.getKey();
                 Iterator<Edge> edges = this.edgesOfVertex(vertex,
-                                                          step.edgeStep);
+                                                          step.edgeStep, false);
 
                 Adjacencies adjacenciesV = new Adjacencies(vertex);
                 Set<Id> sameLayerNodesV = newIdSet();

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/PathTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/PathTraverser.java
@@ -143,7 +143,7 @@ public abstract class PathTraverser {
             return;
         }
 
-        Iterator<Edge> edges = this.traverser.edgesOfVertex(v, step);
+        Iterator<Edge> edges = this.traverser.edgesOfVertex(v, step, false);
         while (edges.hasNext()) {
             HugeEdge edge = (HugeEdge) edges.next();
             Id target = edge.id().otherVertexId();

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/PathsTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/PathsTraverser.java
@@ -112,7 +112,7 @@ public class PathsTraverser extends HugeTraverser {
             while (this.record.hasNextKey()) {
                 Id vid = this.record.nextKey();
 
-                edges = edgesOfVertex(vid, direction, this.label, this.degree);
+                edges = edgesOfVertex(vid, direction, this.label, this.degree, false);
 
                 while (edges.hasNext()) {
                     HugeEdge edge = (HugeEdge) edges.next();
@@ -141,7 +141,7 @@ public class PathsTraverser extends HugeTraverser {
             this.record.startOneLayer(false);
             while (this.record.hasNextKey()) {
                 Id vid = this.record.nextKey();
-                edges = edgesOfVertex(vid, direction, this.label, this.degree);
+                edges = edgesOfVertex(vid, direction, this.label, this.degree, false);
 
                 while (edges.hasNext()) {
                     HugeEdge edge = (HugeEdge) edges.next();

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/ShortestPathTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/ShortestPathTraverser.java
@@ -165,7 +165,7 @@ public class ShortestPathTraverser extends HugeTraverser {
                 Id source = this.record.nextKey();
 
                 Iterator<Edge> edges = edgesOfVertex(source, this.direction,
-                                                     this.labels, degree);
+                                                     this.labels, degree, false);
                 edges = skipSuperNodeIfNeeded(edges, this.degree,
                                               this.skipDegree);
                 while (edges.hasNext()) {
@@ -205,7 +205,7 @@ public class ShortestPathTraverser extends HugeTraverser {
                 Id source = this.record.nextKey();
 
                 Iterator<Edge> edges = edgesOfVertex(source, opposite,
-                                                     this.labels, degree);
+                                                     this.labels, degree, false);
                 edges = skipSuperNodeIfNeeded(edges, this.degree,
                                               this.skipDegree);
                 while (edges.hasNext()) {
@@ -241,8 +241,11 @@ public class ShortestPathTraverser extends HugeTraverser {
                 return false;
             }
             Iterator<Edge> edges = edgesOfVertex(vertex, direction,
-                                                 this.labels, this.skipDegree);
-            return IteratorUtils.count(edges) >= this.skipDegree;
+                                                 this.labels, this.skipDegree, false);
+            for( int i = 0; i < this.skipDegree && edges.hasNext(); i++ ) {
+                edges.next();
+            }
+            return edges.hasNext();
         }
 
         private long accessed() {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/SingleSourceShortestPathTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/SingleSourceShortestPathTraverser.java
@@ -136,10 +136,12 @@ public class SingleSourceShortestPathTraverser extends HugeTraverser {
          */
         public void forward() {
             long degree = this.skipDegree > 0L ? this.skipDegree : this.degree;
+            boolean withEdgeProperties = this.weight != null;
             for (NodeWithWeight node : this.sources) {
                 Iterator<Edge> edges = edgesOfVertex(node.node().id(),
                                                      this.direction,
-                                                     this.label, degree);
+                                                     this.label, degree,
+                                                     withEdgeProperties);
                 edges = this.skipSuperNodeIfNeeded(edges);
                 while (edges.hasNext()) {
                     HugeEdge edge = (HugeEdge) edges.next();

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/SubGraphTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/SubGraphTraverser.java
@@ -142,7 +142,7 @@ public class SubGraphTraverser extends HugeTraverser {
                 Id vid = entry.getKey();
                 // Record edgeList to determine if multiple edges exist
                 List<Edge> edgeList = IteratorUtils.list(edgesOfVertex(
-                                      vid, direction, this.label, this.degree));
+                                      vid, direction, this.label, this.degree, false));
                 edges = edgeList.iterator();
 
                 if (!edges.hasNext()) {

--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBSessions.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBSessions.java
@@ -79,6 +79,7 @@ public abstract class RocksDBSessions extends BackendSessionPool {
         public static final int SCAN_GTE_BEGIN = 0x0c;
         public static final int SCAN_LT_END = 0x10;
         public static final int SCAN_LTE_END = 0x30;
+        public static final int SCAN_KEYONLY = 0x40;
 
         public abstract String dataPath();
         public abstract String walPath();
@@ -99,9 +100,11 @@ public abstract class RocksDBSessions extends BackendSessionPool {
 
         public abstract byte[] get(String table, byte[] key);
 
-        public abstract BackendColumnIterator scan(String table);
         public abstract BackendColumnIterator scan(String table,
-                                                   byte[] prefix);
+                                                   boolean keyOnly);
+        public abstract BackendColumnIterator scan(String table,
+                                                   byte[] prefix,
+                                                   boolean keyOnly);
         public abstract BackendColumnIterator scan(String table,
                                                    byte[] keyFrom,
                                                    byte[] keyTo,
@@ -109,8 +112,10 @@ public abstract class RocksDBSessions extends BackendSessionPool {
 
         public BackendColumnIterator scan(String table,
                                           byte[] keyFrom,
-                                          byte[] keyTo) {
-            return this.scan(table, keyFrom, keyTo, SCAN_LT_END);
+                                          byte[] keyTo,
+                                          boolean keyOnly) {
+            int scanType = SCAN_LT_END | (keyOnly ? SCAN_KEYONLY : 0);
+            return this.scan(table, keyFrom, keyTo, scanType);
         }
 
         public static boolean matchScanType(int expected, int actual) {

--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdbsst/RocksDBSstSessions.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdbsst/RocksDBSstSessions.java
@@ -416,7 +416,7 @@ public class RocksDBSstSessions extends RocksDBSessions {
          * Scan all records from a table
          */
         @Override
-        public BackendColumnIterator scan(String table) {
+        public BackendColumnIterator scan(String table, boolean keyOnly) {
             assert !this.hasChanges();
             return BackendColumnIterator.empty();
         }
@@ -425,7 +425,8 @@ public class RocksDBSstSessions extends RocksDBSessions {
          * Scan records by key prefix from a table
          */
         @Override
-        public BackendColumnIterator scan(String table, byte[] prefix) {
+        public BackendColumnIterator scan(String table, byte[] prefix,
+                                          boolean keyOnly) {
             assert !this.hasChanges();
             return BackendColumnIterator.empty();
         }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/BaseApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/BaseApiTest.java
@@ -504,7 +504,10 @@ public class BaseApiTest {
             List<Object> ids = list.stream().map(e -> e.get("id"))
                                    .collect(Collectors.toList());
             ids.forEach(id -> {
-                client.delete(path, (String) id);
+                if( id instanceof Integer )
+                    client.delete(path, String.format("%d", id));
+                else
+                    client.delete(path, (String)id);
             });
         };
 

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedPathsApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedPathsApiTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.api.traversers;
+
+import com.baidu.hugegraph.api.BaseApiTest;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+
+public class CustomizedPathsApiTest extends BaseApiTest {
+
+    final static String path = TRAVERSERS_API + "/customizedpaths";
+
+    @Before
+    public void prepareSchema() {
+        BaseApiTest.initPropertyKey();
+        BaseApiTest.initVertexLabel();
+        BaseApiTest.initEdgeLabel();
+        BaseApiTest.initVertex();
+        BaseApiTest.initEdge();
+    }
+
+    @Test
+    public void testPost() {
+        Map<String, String> name2Ids = listAllVertexName2Ids();
+        String markoId = name2Ids.get("marko");
+        String joshId = name2Ids.get("josh");
+        String reqBody = String.format("{ " +
+                                       "\"sources\": { " +
+                                       " \"ids\": [\"%s\"]}, " +
+                                       "\"steps\": [{ " +
+                                       " \"direction\": \"BOTH\", " +
+                                       " \"labels\": [\"knows\"], " +
+                                       " \"weight_by\":\"weight\", " +
+                                       " \"max_degree\":-1}, {" +
+                                       " \"direction\":\"OUT\", " +
+                                       " \"labels\": [\"created\"], " +
+                                       " \"default_weight\":8, "+
+                                       " \"max_degree\":-1, " +
+                                       " \"sample\":1 }], " +
+                                       "\"sort_by\":\"INCR\", " +
+                                       "\"with_vertex\":true}",
+                                       markoId);
+        Response r = client().post(path, reqBody);
+        String content = assertResponseStatus(200, r);
+        List<Map<String, Object>> paths = assertJsonContains(content, "paths");
+        Assert.assertEquals(1, paths.size());
+        List<Map<String, Object>> vertices = assertJsonContains(content, "vertices");
+        Assert.assertEquals(3, vertices.size());
+    }
+}
+

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/traversers/KoutApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/traversers/KoutApiTest.java
@@ -120,39 +120,38 @@ public class KoutApiTest extends BaseApiTest {
     public void testPost() {
         Map<String, String> name2Ids = listAllVertexName2Ids();
         String markoId = name2Ids.get("marko");
+
         String reqBody = String.format(postParams, markoId, "breadth_first");
-        Response resp = client().post(path, reqBody);
-        String content = assertResponseStatus(200, resp);
+        String content = doPost(reqBody);
         Object size = assertJsonContains(content, "size");
         Assert.assertEquals(2, size);
-        assertJsonContains(content, "kout");
-        assertJsonContains(content, "paths");
-        assertJsonContains(content, "vertices");
-        assertJsonContains(content, "edges");
-        assertJsonContains(content, "measure");
 
         // for deep-first
         reqBody = String.format(postParams, markoId, "deep_first");
-        resp = client().post(path, reqBody);
-        content = assertResponseStatus(200, resp);
+        content = doPost(reqBody);
         size = assertJsonContains(content, "size");
         Assert.assertEquals(2, size);
-        assertJsonContains(content, "kout");
-        assertJsonContains(content, "paths");
-        assertJsonContains(content, "vertices");
-        assertJsonContains(content, "edges");
-        assertJsonContains(content, "measure");
 
         // for count-only
         reqBody = String.format(postParamsForCountOnly, markoId, "BOTH");
-        resp = client().post(path, reqBody);
-        content = assertResponseStatus(200, resp);
+        content = doPost(reqBody);
         size = assertJsonContains(content, "size");
         Assert.assertEquals(1, size);
+
+        reqBody = String.format(postParamsForCountOnly, markoId, "OUT");
+        content = doPost(reqBody);
+        size = assertJsonContains(content, "size");
+        Assert.assertEquals(1, size);
+    }
+
+    public String doPost(String reqBody) {
+        Response resp = client().post(path, reqBody);
+        String content = assertResponseStatus(200, resp);
         assertJsonContains(content, "kout");
         assertJsonContains(content, "paths");
         assertJsonContains(content, "vertices");
         assertJsonContains(content, "edges");
         assertJsonContains(content, "measure");
+        return content;
     }
 }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/traversers/TraversersApiTestSuite.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/traversers/TraversersApiTestSuite.java
@@ -28,6 +28,7 @@ import org.junit.runners.Suite;
     CountApiTest.class,
     CrosspointsApiTest.class,
     CustomizedCrosspointsApiTest.class,
+    CustomizedPathsApiTest.class,
     EdgesApiTest.class,
     FusiformSimilarityApiTest.class,
     JaccardSimilarityApiTest.class,

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/rocksdb/RocksDBPerfTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/rocksdb/RocksDBPerfTest.java
@@ -92,7 +92,7 @@ public class RocksDBPerfTest extends BaseRocksDBUnitTest {
 
         Session session = this.rocks.session();
         for (int i = 0; i < TIMES; i++) {
-            Iterator<BackendColumn> iter = session.scan(TABLE, b("person:1"));
+            Iterator<BackendColumn> iter = session.scan(TABLE, b("person:1"), false);
             while (iter.hasNext()) {
                 BackendColumn col = iter.next();
                 s(col.name);
@@ -164,7 +164,7 @@ public class RocksDBPerfTest extends BaseRocksDBUnitTest {
         for (int j = 0; j < queryTimes; j++) {
             for (int i = 0; i < n; i++) {
                 String key = String.format("index:%3d", i);
-                Iterator<BackendColumn> iter = session.scan(TABLE, b(key));
+                Iterator<BackendColumn> iter = session.scan(TABLE, b(key), false);
                 while (iter.hasNext()) {
                     iter.next();
                 }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/rocksdb/RocksDBSessionTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/rocksdb/RocksDBSessionTest.java
@@ -123,7 +123,7 @@ public class RocksDBSessionTest extends BaseRocksDBUnitTest {
 
         Map<String, String> results = new HashMap<>();
         Session session = this.rocks.session();
-        Iterator<BackendColumn> iter = session.scan(TABLE, b("person:1"));
+        Iterator<BackendColumn> iter = session.scan(TABLE, b("person:1"), false);
         while (iter.hasNext()) {
             BackendColumn col = iter.next();
             results.put(s(col.name), s(col.value));
@@ -155,7 +155,8 @@ public class RocksDBSessionTest extends BaseRocksDBUnitTest {
         Session session = this.rocks.session();
         Iterator<BackendColumn> iter = session.scan(TABLE,
                                                     b("person:1"),
-                                                    b("person:3"));
+                                                    b("person:3"),
+                                                    false);
         while (iter.hasNext()) {
             BackendColumn col = iter.next();
             results.put(s(col.name), s(col.value));
@@ -202,7 +203,8 @@ public class RocksDBSessionTest extends BaseRocksDBUnitTest {
         Map<ByteBuffer, byte[]> results = new HashMap<>();
         Iterator<BackendColumn> iter = session.scan(TABLE,
                                                     new byte[]{1, 0},
-                                                    new byte[]{2, 3});
+                                                    new byte[]{2, 3},
+                                                    false);
         while (iter.hasNext()) {
             BackendColumn col = iter.next();
             results.put(ByteBuffer.wrap(col.name), col.value);
@@ -241,10 +243,10 @@ public class RocksDBSessionTest extends BaseRocksDBUnitTest {
 
         Iterator<BackendColumn> iter;
 
-        iter = session.scan(TABLE, new byte[]{1, -1}, new byte[]{1, 3});
+        iter = session.scan(TABLE, new byte[]{1, -1}, new byte[]{1, 3}, false);
         Assert.assertFalse(iter.hasNext());
 
-        iter = session.scan(TABLE, new byte[]{1, 1}, new byte[]{1, -1});
+        iter = session.scan(TABLE, new byte[]{1, 1}, new byte[]{1, -1}, false);
         Map<ByteBuffer, byte[]> results = new HashMap<>();
         while (iter.hasNext()) {
             BackendColumn col = iter.next();


### PR DESCRIPTION
Optimizing by skipping unncessary edge properties deserialization will improve performance by about 50% for most TP-traverser algorithm. 