### PR TITLE
透传图空间字段到后端用于存储初始化

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/core/GraphManager.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/core/GraphManager.java
@@ -680,6 +680,7 @@ public final class GraphManager {
                         "The graph name '%s' has existed", name);
 
         configs.put(ServerOptions.PD_PEERS.name(), this.pdPeers);
+        configs.put(CoreOptions.GRAPH_SPACE.name(), graphSpace);
         boolean auth = this.metaManager.graphSpace(graphSpace).auth();
         if (DEFAULT_GRAPH_SPACE_NAME.equals(graphSpace) || !auth) {
             configs.put("gremlin.graph", "com.baidu.hugegraph.HugeFactory");

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
@@ -164,7 +164,7 @@ public class StandardHugeGraph implements HugeGraph {
     public StandardHugeGraph(HugeConfig config) {
         this.params = new StandardHugeGraphParams();
         this.configuration = config;
-        this.graphSpace = "";
+        this.graphSpace = config.get(CoreOptions.GRAPH_SPACE);
 
         this.schemaEventHub = new EventHub("schema");
         this.graphEventHub = new EventHub("graph");

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/config/CoreOptions.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/config/CoreOptions.java
@@ -48,6 +48,14 @@ public class CoreOptions extends OptionHolder {
         return instance;
     }
 
+    public static final ConfigOption<String> GRAPH_SPACE =
+            new ConfigOption<>(
+                    "graphspace",
+                    "The graph space name.",
+                    null,
+                    ""
+            );
+
     public static final ConfigOption<String> GREMLIN_GRAPH =
             new ConfigOption<>(
                     "gremlin.graph",

--- a/hugegraph-dist/src/assembly/static/conf/rest-server.properties
+++ b/hugegraph-dist/src/assembly/static/conf/rest-server.properties
@@ -24,6 +24,17 @@ batch.max_edges_per_batch=2000
 # authentication configs
 auth.authenticator=com.baidu.hugegraph.auth.StandardAuthenticator
 
+# k8s configs
+server.use_k8s=false
+server.k8s_url=https://127.0.0.1:6443
+server.k8s_use_ca=true
+server.k8s_ca=/etc/kubernetes/ssl/ca.pem
+server.k8s_client_ca=/etc/kubernetes/ssl/kubernetes.pem
+server.k8s_client_key=/etc/kubernetes/ssl/kubernetes-key8.pem
+server.k8s_oltp_image=xx.xx.xx.xx/kgs_bd/hugegraphserver:3.0.0
+server.k8s_olap_image=xx.xx.xx.xx/kgs_bd/hugegraph/hugegraph-computer-based-algorithm:beta1
+server.k8s_storage_image=xx.xx.xx.xx/kgs_bd/xxxxx:3.0.0
+
 # k8s api, default not support
 k8s.api=false
 k8s.namespace=hugegraph-computer-system


### PR DESCRIPTION
01. 透传图空间字段到后端用于存储初始化
02. 配置文件增加 K8S 配置选项